### PR TITLE
Show toast on successful copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,11 +277,17 @@
         const finalStr = `[${timestamp} ${await locationString}; ${await weatherInfo}]`
         try {
           await clipboardWriter.writeText(finalStr)
-          this.status += '<br>Copied!'
+          this.$buefy.toast.open({
+            message: finalStr,
+            type: 'is-success'
+          })
         }
         catch (e) {
           console.error('Clipboard error', e)
-          this.status += '<br>Clipboard error.'
+          this.$buefy.toast.open({
+            message: 'Clipboard error.',
+            type: 'is-danger'
+          })
         }
       },
       saveLocation() {


### PR DESCRIPTION
## Summary
- notify user with a green toast showing copied text
- display a red toast on clipboard error

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6868950cbf98832f8293266e7024289b